### PR TITLE
Improve AgentDashboard resilience to partial SSE payloads

### DIFF
--- a/agent-orchestrator/web/package.json
+++ b/agent-orchestrator/web/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "agent-orchestrator-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "14.1.2",
+    "@testing-library/jest-dom": "6.2.0",
+    "@types/react": "18.2.43",
+    "@types/react-dom": "18.2.17",
+    "jsdom": "22.1.0",
+    "typescript": "5.3.3",
+    "vitest": "1.2.1"
+  }
+}

--- a/agent-orchestrator/web/src/components/AgentDashboard.tsx
+++ b/agent-orchestrator/web/src/components/AgentDashboard.tsx
@@ -1,0 +1,243 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+export type ExecutionPlanStep = {
+  id?: string;
+  title?: string;
+  description?: string;
+  detail?: string;
+  status?: string;
+};
+
+export type ExecutionPlan = {
+  title?: string;
+  summary?: string;
+  steps?: Array<ExecutionPlanStep | null | undefined> | null;
+};
+
+export type ExecutionTask = {
+  id?: string;
+  label?: string;
+  description?: string;
+  status?: string;
+};
+
+export type ExecutionState = {
+  id?: string;
+  status?: string;
+  plan?: ExecutionPlan | null;
+  tasks?: Array<ExecutionTask | null | undefined> | null;
+};
+
+export type EventPayload = {
+  execution?: ExecutionState | null;
+};
+
+export type MessageEventLike<T = string> = {
+  data: T;
+};
+
+export interface EventSourceLike {
+  addEventListener(
+    type: string,
+    listener: (event: MessageEventLike<string>) => void
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: (event: MessageEventLike<string>) => void
+  ): void;
+  close(): void;
+}
+
+export interface AgentDashboardProps {
+  sseUrl: string;
+  createEventSource?: (url: string) => EventSourceLike;
+}
+
+function defaultCreateEventSource(url: string): EventSourceLike {
+  return new EventSource(url);
+}
+
+function sanitizeText(value?: string | null, placeholder: string = "—"): string {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : placeholder;
+}
+
+const EMPTY_PLAN_PLACEHOLDERS = {
+  title: "Awaiting plan title…",
+  summary: "Awaiting plan summary…",
+  steps: "No plan steps yet.",
+};
+
+const EMPTY_TASKS_PLACEHOLDER = "No tasks have been scheduled.";
+
+export const AgentDashboard: React.FC<AgentDashboardProps> = ({
+  sseUrl,
+  createEventSource,
+}) => {
+  const [execution, setExecution] = useState<ExecutionState | null>(null);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const factory = createEventSource ?? defaultCreateEventSource;
+    const eventSource = factory(sseUrl);
+
+    const handleMessage = (event: MessageEventLike<string>) => {
+      if (!isMounted) return;
+
+      try {
+        const payload: EventPayload = JSON.parse(event.data ?? "{}");
+        if (payload?.execution) {
+          setExecution(payload.execution);
+        }
+      } catch (error) {
+        console.warn("Failed to parse execution payload", error);
+      }
+    };
+
+    const handleError = () => {
+      if (!isMounted) return;
+      setConnectionError("Connection lost. Retrying…");
+    };
+
+    eventSource.addEventListener("message", handleMessage);
+    eventSource.addEventListener("error", handleError);
+
+    return () => {
+      isMounted = false;
+      eventSource.removeEventListener("message", handleMessage);
+      eventSource.removeEventListener("error", handleError);
+      eventSource.close();
+    };
+  }, [sseUrl, createEventSource]);
+
+  const plan = execution?.plan ?? {};
+
+  const planSteps = useMemo(() => {
+    if (!plan || !Array.isArray(plan.steps)) {
+      return [] as ExecutionPlanStep[];
+    }
+
+    return plan.steps
+      .filter((step): step is ExecutionPlanStep => Boolean(step))
+      .map((step, index) => ({
+        ...step,
+        id: step?.id ?? `step-${index}`,
+      }));
+  }, [plan]);
+
+  const tasks = useMemo(() => {
+    if (!execution || !Array.isArray(execution.tasks)) {
+      return [] as ExecutionTask[];
+    }
+
+    return execution.tasks
+      .filter((task): task is ExecutionTask => Boolean(task))
+      .map((task, index) => ({
+        ...task,
+        id: task?.id ?? `task-${index}`,
+      }));
+  }, [execution]);
+
+  const title = sanitizeText(plan?.title, EMPTY_PLAN_PLACEHOLDERS.title);
+  const summary = sanitizeText(plan?.summary, EMPTY_PLAN_PLACEHOLDERS.summary);
+
+  return (
+    <div className="agent-dashboard" role="region" aria-live="polite">
+      <header className="agent-dashboard__header">
+        <h2 className="agent-dashboard__title">{title}</h2>
+        <p className="agent-dashboard__summary">{summary}</p>
+      </header>
+
+      {connectionError ? (
+        <div className="agent-dashboard__error" role="status">
+          {connectionError}
+        </div>
+      ) : null}
+
+      <section className="agent-dashboard__plan" aria-label="Execution plan">
+        {planSteps.length > 0 ? (
+          <ol className="agent-dashboard__plan-steps">
+            {planSteps.map((step, index) => {
+              const stepTitle = sanitizeText(
+                step.title ?? step.description ?? step.detail,
+                `Step ${index + 1}`
+              );
+              const description = sanitizeText(
+                step.description ?? step.detail,
+                "Awaiting step details…"
+              );
+              const status = sanitizeText(step.status, "pending");
+
+              return (
+                <li className="agent-dashboard__plan-step" key={step.id ?? index}>
+                  <div className="agent-dashboard__plan-step-header">
+                    <span className="agent-dashboard__plan-step-index">
+                      {index + 1}.
+                    </span>
+                    <span className="agent-dashboard__plan-step-title">
+                      {stepTitle}
+                    </span>
+                  </div>
+                  <p className="agent-dashboard__plan-step-description">
+                    {description}
+                  </p>
+                  <span className="agent-dashboard__plan-step-status">
+                    Status: {status}
+                  </span>
+                </li>
+              );
+            })}
+          </ol>
+        ) : (
+          <p className="agent-dashboard__plan-placeholder">
+            {EMPTY_PLAN_PLACEHOLDERS.steps}
+          </p>
+        )}
+      </section>
+
+      <section className="agent-dashboard__tasks" aria-label="Tasks">
+        <h3>Tasks</h3>
+        {tasks.length > 0 ? (
+          <ul className="agent-dashboard__task-list">
+            {tasks.map((task, index) => {
+              const taskLabel = sanitizeText(
+                task.label ?? task.description,
+                `Task ${index + 1}`
+              );
+              const status = sanitizeText(task.status, "pending");
+
+              return (
+                <li className="agent-dashboard__task" key={task.id ?? index}>
+                  <span className="agent-dashboard__task-label">{taskLabel}</span>
+                  <span className="agent-dashboard__task-status">
+                    Status: {status}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className="agent-dashboard__tasks-placeholder">
+            {EMPTY_TASKS_PLACEHOLDER}
+          </p>
+        )}
+      </section>
+
+      <section className="agent-dashboard__metadata" aria-label="Execution metadata">
+        <dl>
+          <div>
+            <dt>Status</dt>
+            <dd>{sanitizeText(execution?.status, "Unknown")}</dd>
+          </div>
+          <div>
+            <dt>Execution ID</dt>
+            <dd>{sanitizeText(execution?.id, "—")}</dd>
+          </div>
+        </dl>
+      </section>
+    </div>
+  );
+};
+
+export default AgentDashboard;

--- a/agent-orchestrator/web/src/components/__tests__/AgentDashboard.test.tsx
+++ b/agent-orchestrator/web/src/components/__tests__/AgentDashboard.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import AgentDashboard, {
+  AgentDashboardProps,
+  EventSourceLike,
+  MessageEventLike,
+} from "../AgentDashboard";
+
+type Listener = (event: MessageEventLike<string>) => void;
+
+class MockEventSource implements EventSourceLike {
+  private listeners: Record<string, Set<Listener>> = {};
+
+  addEventListener(type: string, listener: Listener) {
+    if (!this.listeners[type]) {
+      this.listeners[type] = new Set();
+    }
+    this.listeners[type].add(listener);
+  }
+
+  removeEventListener(type: string, listener: Listener) {
+    this.listeners[type]?.delete(listener);
+  }
+
+  close() {
+    this.listeners = {};
+  }
+
+  emit(type: string, data: string) {
+    const listeners = this.listeners[type];
+    if (!listeners) return;
+    const event: MessageEventLike<string> = { data };
+    listeners.forEach((listener) => listener(event));
+  }
+}
+
+describe("AgentDashboard", () => {
+  const setup = () => {
+    const mockSource = new MockEventSource();
+    const props: AgentDashboardProps = {
+      sseUrl: "/sse",
+      createEventSource: () => mockSource,
+    };
+
+    render(<AgentDashboard {...props} />);
+
+    return { mockSource };
+  };
+
+  it("renders placeholders when plan data is missing", async () => {
+    const { mockSource } = setup();
+
+    await act(async () => {
+      mockSource.emit(
+        "message",
+        JSON.stringify({
+          execution: {
+            id: "exec-1",
+            status: "running",
+          },
+        })
+      );
+    });
+
+    expect(await screen.findByText("Awaiting plan title…")).toBeInTheDocument();
+    expect(screen.getByText("Awaiting plan summary…")).toBeInTheDocument();
+    expect(screen.getByText("No plan steps yet.")).toBeInTheDocument();
+    expect(screen.getByText("No tasks have been scheduled.")).toBeInTheDocument();
+    expect(screen.getByText("Status: pending")).toBeInTheDocument();
+  });
+});

--- a/agent-orchestrator/web/tsconfig.json
+++ b/agent-orchestrator/web/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "lib": ["DOM", "ES2020"],
+    "types": ["vitest", "@testing-library/jest-dom"]
+  },
+  "include": ["src"]
+}

--- a/agent-orchestrator/web/vitest.config.ts
+++ b/agent-orchestrator/web/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    globals: true,
+  },
+});

--- a/agent-orchestrator/web/vitest.setup.ts
+++ b/agent-orchestrator/web/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";


### PR DESCRIPTION
## Summary
- add an AgentDashboard component that defensively renders plan, task, and execution details when plan/task data is missing
- expose a mockable EventSource factory and provide placeholders so the UI remains stable with partial SSE payloads
- introduce a Vitest test that feeds an SSE message without plan information to confirm the component stays mounted

## Testing
- npm test *(fails: Vitest dependency unavailable because npm registry access is restricted in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c211bf88832c9325038df47ed187