### PR TITLE
Harden coordinator planning against empty task lists

### DIFF
--- a/agent-orchestrator/package.json
+++ b/agent-orchestrator/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "agent-orchestrator",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.10",
+    "typescript": "^5.3.3",
+    "vitest": "^1.2.0"
+  }
+}

--- a/agent-orchestrator/src/agents/coordinator.ts
+++ b/agent-orchestrator/src/agents/coordinator.ts
@@ -1,0 +1,121 @@
+export interface Task {
+  id: string;
+  description: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+export interface Plan {
+  tasks: Task[];
+}
+
+export interface PlanParsingOptions {
+  fallbackTask?: Partial<Task>;
+}
+
+function extractJsonCandidate(raw: string): string | null {
+  const fenceMatch = raw.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenceMatch) {
+    return fenceMatch[1];
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed;
+}
+
+function parseJsonSafe(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeTask(raw: unknown, index: number): Task | null {
+  if (typeof raw !== "object" || raw === null) {
+    return null;
+  }
+
+  const data = raw as Record<string, unknown>;
+  const descriptionCandidate =
+    typeof data.description === "string"
+      ? data.description
+      : typeof data.summary === "string"
+      ? data.summary
+      : typeof data.task === "string"
+      ? data.task
+      : "";
+
+  const description = descriptionCandidate.trim();
+  if (!description) {
+    return null;
+  }
+
+  const idCandidate =
+    typeof data.id === "string" && data.id.trim().length > 0
+      ? data.id.trim()
+      : `task-${index + 1}`;
+
+  const normalizedTask: Task = {
+    ...data,
+    id: idCandidate,
+    description,
+  };
+
+  return normalizedTask;
+}
+
+function buildFallbackTask(fallback?: Partial<Task>): Task {
+  const fallbackDescription = fallback?.description;
+  const trimmedDescription =
+    typeof fallbackDescription === "string" ? fallbackDescription.trim() : "";
+  const fallbackId = fallback?.id;
+  const normalizedId =
+    typeof fallbackId === "string" && fallbackId.trim().length > 0
+      ? fallbackId.trim()
+      : fallbackId != null
+      ? String(fallbackId)
+      : "";
+
+  return {
+    ...fallback,
+    id: normalizedId || "fallback-task",
+    description:
+      trimmedDescription && trimmedDescription.length > 0
+        ? trimmedDescription
+        : "Analyze the request and outline the immediate next step.",
+  } satisfies Task;
+}
+
+export class CoordinatorAgent {
+  constructor(private readonly options: PlanParsingOptions = {}) {}
+
+  plan(rawResponse: string): Plan {
+    const candidate = extractJsonCandidate(rawResponse ?? "");
+    if (candidate) {
+      const parsed = parseJsonSafe(candidate);
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        "tasks" in (parsed as Record<string, unknown>)
+      ) {
+        const { tasks } = parsed as { tasks?: unknown };
+        if (Array.isArray(tasks) && tasks.length > 0) {
+          const normalized = tasks
+            .map((task, index) => normalizeTask(task, index))
+            .filter((task): task is Task => Boolean(task));
+
+          if (normalized.length > 0) {
+            return { tasks: normalized };
+          }
+        }
+      }
+    }
+
+    return { tasks: [buildFallbackTask(this.options.fallbackTask)] };
+  }
+}
+
+export default CoordinatorAgent;

--- a/agent-orchestrator/tests/coordinator.test.ts
+++ b/agent-orchestrator/tests/coordinator.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import CoordinatorAgent, { Task } from "../src/agents/coordinator";
+
+describe("CoordinatorAgent.plan", () => {
+  it("falls back to single task when parsed tasks array is empty", () => {
+    const agent = new CoordinatorAgent({
+      fallbackTask: {
+        id: "safety-net",
+        description: "Draft a minimal viable plan.",
+      },
+    });
+
+    const result = agent.plan(
+      JSON.stringify({
+        tasks: [],
+      })
+    );
+
+    expect(result.tasks).toHaveLength(1);
+    expect(result.tasks[0]).toMatchObject({
+      id: "safety-net",
+      description: "Draft a minimal viable plan.",
+    });
+  });
+
+  it("normalizes parsed tasks and filters out invalid entries", () => {
+    const agent = new CoordinatorAgent();
+    const plan = agent.plan(
+      JSON.stringify({
+        tasks: [
+          { id: "  task-alpha  ", description: "  Research API options  " },
+          { description: "" },
+          null,
+          { summary: "Review findings" },
+        ],
+      })
+    );
+
+    expect(plan.tasks).toHaveLength(2);
+    const [first, second] = plan.tasks as Task[];
+
+    expect(first.id).toBe("task-alpha");
+    expect(first.description).toBe("Research API options");
+
+    expect(second.id).toBe("task-4");
+    expect(second.description).toBe("Review findings");
+  });
+});

--- a/agent-orchestrator/tsconfig.json
+++ b/agent-orchestrator/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src", "tests", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/agent-orchestrator/vitest.config.ts
+++ b/agent-orchestrator/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    coverage: {
+      reporter: ["text", "html"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a coordinator agent implementation that normalizes parsed tasks
- ensure fallback planning kicks in when the response omits actionable tasks
- cover the planner with Vitest cases for empty and malformed task arrays

## Testing
- npm test *(fails: `vitest` not found because dependencies could not be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e207b488d4832c8a3b58d34443c82c