### PR TITLE
Add Docker setup for orchestrator API and web frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Node dependencies
+node_modules/
+**/node_modules/
+
+# Build outputs
+**/dist/
+
+# Environment files
+.env
+**/.env
+.env.local
+
+# Logs
+npm-debug.log*
+yarn-error.log*
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -33,3 +33,22 @@ you require the updated credential.
    this file).
 3. Ensure the `OPENAI_API_KEY` environment variable is set when running
    services locally or via Docker Compose.
+
+## Docker Compose workflow
+
+The repository provides Dockerfiles for both the orchestrator API and the web
+frontend. With your `.env` file in place and `OPENAI_API_KEY` exported in your
+shell, launch the stack with:
+
+```sh
+docker compose up --build
+```
+
+Compose builds two images:
+
+- `agent-orchestrator`: a Node.js service that exposes the API on port `3000`.
+- `orchestrator-web`: an Nginx container that serves the static frontend on
+  port `4173`.
+
+No additional build arguments are required—the services rely solely on the
+`OPENAI_API_KEY` environment variable supplied at runtime.

--- a/agent-orchestrator/.dockerignore
+++ b/agent-orchestrator/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+npm-debug.log*
+yarn-error.log*
+.env
+.env.local
+dist
+web/node_modules
+web/dist

--- a/agent-orchestrator/Dockerfile
+++ b/agent-orchestrator/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.6
+
+FROM node:20-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+FROM node:20-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY package.json package-lock.json ./
+EXPOSE 3000
+CMD ["node", "dist/server.js"]

--- a/agent-orchestrator/package-lock.json
+++ b/agent-orchestrator/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "agent-orchestrator",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-orchestrator",
+      "version": "0.1.0",
+      "devDependencies": {}
+    }
+  }
+}

--- a/agent-orchestrator/package.json
+++ b/agent-orchestrator/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "agent-orchestrator",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "dev": "node src/server.js",
+    "build": "node scripts/build.js",
+    "start": "node dist/server.js",
+    "test": "node -e \"console.log('No tests defined')\""
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/agent-orchestrator/scripts/build.js
+++ b/agent-orchestrator/scripts/build.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const source = path.join(__dirname, '..', 'src', 'server.js');
+const destinationDir = path.join(__dirname, '..', 'dist');
+const destination = path.join(destinationDir, 'server.js');
+
+if (!fs.existsSync(source)) {
+  console.error(`Source file not found: ${source}`);
+  process.exit(1);
+}
+
+fs.mkdirSync(destinationDir, { recursive: true });
+fs.copyFileSync(source, destination);
+console.log(`Copied ${source} -> ${destination}`);

--- a/agent-orchestrator/src/server.js
+++ b/agent-orchestrator/src/server.js
@@ -1,0 +1,40 @@
+const http = require('http');
+const { URL } = require('url');
+
+const port = Number(process.env.PORT ?? 3000);
+
+const server = http.createServer((req, res) => {
+  if (!req.url) {
+    res.statusCode = 400;
+    res.end('Bad request');
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host ?? 'localhost'}`);
+
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+
+  if (url.pathname === '/health') {
+    res.end(JSON.stringify({ status: 'ok' }));
+    return;
+  }
+
+  if (url.pathname === '/') {
+    res.end(
+      JSON.stringify({
+        name: 'Ultimate Agent Orchestrator',
+        version: '0.1.0',
+        openaiKeyConfigured: Boolean(process.env.OPENAI_API_KEY)
+      })
+    );
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end(JSON.stringify({ error: 'Not found' }));
+});
+
+server.listen(port, () => {
+  console.log(`Agent orchestrator listening on port ${port}`);
+});

--- a/agent-orchestrator/web/.dockerignore
+++ b/agent-orchestrator/web/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+npm-debug.log*
+yarn-error.log*

--- a/agent-orchestrator/web/Dockerfile
+++ b/agent-orchestrator/web/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1.6
+
+FROM node:20-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine AS runner
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/agent-orchestrator/web/nginx.conf
+++ b/agent-orchestrator/web/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,19 @@ version: "3.9"
 
 services:
   agent-orchestrator:
-    build: ./agent-orchestrator
+    build:
+      context: ./agent-orchestrator
+    ports:
+      - "3000:3000"
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:?OPENAI_API_KEY must be set before starting Docker Compose}
+      - PORT=3000
     env_file:
       - agent-orchestrator/.env
+  orchestrator-web:
+    build:
+      context: ./agent-orchestrator/web
+    ports:
+      - "4173:80"
+    depends_on:
+      - agent-orchestrator


### PR DESCRIPTION
## Summary
- add a lightweight Node.js orchestrator service and build script so the API can be packaged for production
- create Dockerfiles (and accompanying .dockerignore files) for the API and Vite frontend and update docker-compose to run both containers
- document the new Docker Compose workflow and ports in the README

## Testing
- npm run build
- docker compose up --build *(fails locally: docker is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e207b82df8832ca47a4bd61b41e09a