### PR TITLE
Ensure Fly secret is applied before API deploy

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only
+      - run: flyctl secrets set OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} --app ultimate-agent-api
         working-directory: agent-orchestrator
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-      - run: flyctl secrets set OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} --stage
+      - run: flyctl deploy --remote-only
         working-directory: agent-orchestrator
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- set the OPENAI_API_KEY secret before the Fly API deployment so the container boots with the variable
- remove the --stage flag and target the ultimate-agent-api app explicitly when assigning the secret

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e2afb8dc68832c9f0e884dd95c03e1